### PR TITLE
add retry policy

### DIFF
--- a/iwf.yaml
+++ b/iwf.yaml
@@ -278,6 +278,23 @@ components:
           enum:
             - KEYWORD
             - INT
+    RetryPolicy:
+      type: object
+      required:
+        - initialInterval
+      properties:
+        initialInterval:
+          type: number
+        backoffCoefficient:
+          type: number
+        maximumInterval:
+          type: number
+        maximumAttempts:
+          type: integer
+        nonRetryableErrorTypes:
+          type: array
+          items:
+            type: string
     WorkflowStateOptions:
       type: object
       properties:
@@ -299,6 +316,8 @@ components:
             - TERMINATE_IF_RUNNING
         cronSchedule:
           type: string
+        retryPolicy:
+          $ref: '#/components/schemas/RetryPolicy'
     AttributesLoadingPolicy:
       type: object
       properties:


### PR DESCRIPTION
Cadence:
		InitialInterval time.Duration (**Required**)
		BackoffCoefficient float64
		MaximumInterval time.Duration
		ExpirationInterval time.Duration (**Not present in temporal retry policy**)
		MaximumAttempts int32
		NonRetriableErrorReasons []string
Temporal:
                 InitialInterval time.Duration
		BackoffCoefficient float64
		MaximumInterval time.Duration
		MaximumAttempts int32
		NonRetryableErrorTypes []string

In this definition, InitialInterval is required, and ExpirationInterval is not available