### PR TITLE
IWF-99: Fixing typo IdReusePolicy of ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY

### DIFF
--- a/iwf-sdk.yaml
+++ b/iwf-sdk.yaml
@@ -546,7 +546,7 @@ components:
     IDReusePolicy:
       type: string
       enum:
-        - ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY
+        - ALLOW_IF_PREVIOUS_EXITS_ABNORMALLY
         - ALLOW_IF_NO_RUNNING
         - DISALLOW_REUSE
         - ALLOW_TERMINATE_IF_RUNNING

--- a/iwf.yaml
+++ b/iwf.yaml
@@ -576,7 +576,8 @@ components:
     IDReusePolicy:
       type: string
       enum:
-        - ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY
+        - ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY # Keeping typo enum for backwards compatibility
+        - ALLOW_IF_PREVIOUS_EXITS_ABNORMALLY
         - ALLOW_IF_NO_RUNNING
         - DISALLOW_REUSE
         - ALLOW_TERMINATE_IF_RUNNING


### PR DESCRIPTION
Fix typo IdReusePolicy of ALLOW_IF_PREVIOUS_EXISTS_ABNORMALLY

```
Note that this will be a breaking change for the SDK.....

Note:
Keep the two values (old and new) in [iwf.yaml](https://github.com/indeedeng/iwf-idl/blob/main/iwf.yaml) - server remains backwardly compatible
Only have the one new value in [iwf-sdk.yaml](https://github.com/indeedeng/iwf-idl/blob/main/iwf-sdk.yaml) - SDK will only use the new and correct version
```