### PR TITLE
IWF-137: Allow to use separate persistency loading policy for waitUntil

### DIFF
--- a/iwf-sdk.yaml
+++ b/iwf-sdk.yaml
@@ -503,6 +503,8 @@ components:
       properties:
         searchAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'
+        dataAttributesLoadingPolicy:
+          $ref: '#/components/schemas/PersistenceLoadingPolicy'
         waitUntilApiDataAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'
         executeApiDataAttributesLoadingPolicy:

--- a/iwf-sdk.yaml
+++ b/iwf-sdk.yaml
@@ -503,7 +503,9 @@ components:
       properties:
         searchAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'
-        dataAttributesLoadingPolicy:
+        waitUntilApiDataAttributesLoadingPolicy:
+          $ref: '#/components/schemas/PersistenceLoadingPolicy'
+        executeApiDataAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'
         waitUntilApiTimeoutSeconds: # NOTE: this is the timeout for the single attempt of Cadence/Temporal activity(start to close timeout)
           type: integer

--- a/iwf.yaml
+++ b/iwf.yaml
@@ -541,7 +541,7 @@ components:
           $ref: '#/components/schemas/WaitUntilApiFailurePolicy'
         skipWaitUntil:
           type: boolean
-        dataAttributesLoadingPolicy: # deprecated in favor of waitUntilApiDataAttributesLoadingPolicy and executeApiDataAttributesLoadingPolicy
+        dataAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'
         waitUntilApiDataAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'

--- a/iwf.yaml
+++ b/iwf.yaml
@@ -541,7 +541,11 @@ components:
           $ref: '#/components/schemas/WaitUntilApiFailurePolicy'
         skipWaitUntil:
           type: boolean
-        dataAttributesLoadingPolicy:
+        dataAttributesLoadingPolicy: # deprecated in favor of waitUntilApiDataAttributesLoadingPolicy and executeApiDataAttributesLoadingPolicy
+          $ref: '#/components/schemas/PersistenceLoadingPolicy'
+        waitUntilApiDataAttributesLoadingPolicy:
+          $ref: '#/components/schemas/PersistenceLoadingPolicy'
+        executeApiDataAttributesLoadingPolicy:
           $ref: '#/components/schemas/PersistenceLoadingPolicy'
     WorkflowStartOptions:
       type: object


### PR DESCRIPTION
- Adding waitUntilApiDataAttributesLoadingPolicy and executeApiDataAttributesLoadingPolicy
- ~~Deprecate dataAttributesLoadingPolicy~~
