### PR TITLE
Remove unnecessary field from ChannelInfo

### DIFF
--- a/iwf-sdk.yaml
+++ b/iwf-sdk.yaml
@@ -1035,8 +1035,6 @@ components:
     ChannelInfo:
       type: object
       properties:
-        name:
-          type: string
         size:
           type: integer
     WorkflowWorkerRpcResponse:

--- a/iwf.yaml
+++ b/iwf.yaml
@@ -1117,8 +1117,6 @@ components:
     ChannelInfo:
       type: object
       properties:
-        name:
-          type: string
         size:
           type: integer
     WorkflowWorkerRpcResponse:


### PR DESCRIPTION
Since it’s a map, I will remove the name from the model to save the bytes…This is especially useful later when we pass the map to state execution — the map will be persisted into the history which impacts the storage cost