### PR TITLE
IWF-511: Add a error field to the IwfEvent struct

### DIFF
--- a/iwf.yaml
+++ b/iwf.yaml
@@ -1539,6 +1539,13 @@ components:
         endTimestampInMs: # only applicable for certain events
           type: integer
           format: int64
+        error:
+          type: object
+          properties:
+            type:
+              type: string
+            details:
+              type: string
         searchAttributes:
           type: array
           items:


### PR DESCRIPTION
Adding a error field to the IwfEvent struct, with two properties, to hold the error type and the error detail